### PR TITLE
Only clone current state of lib/

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -64,7 +64,7 @@ fi
 	apt-get -qq -y --no-install-recommends install git
 
 if [[ ! -d $SRC/lib ]]; then
-	git clone https://github.com/igorpecovnik/lib
+	git clone --depth 1 https://github.com/igorpecovnik/lib
 fi
 cd $SRC/lib
 if [[ ! -f $SRC/.ignore_changes ]]; then


### PR DESCRIPTION
It's not necessary to clone the whole history, the current state is enough here.
It safes time and space.
